### PR TITLE
docs and api: expand server setup steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,11 +25,25 @@ The project uses React and TailwindCSS for the frontend, and FastAPI with Whispe
    ```sh
    pip install -r backend/requirements.txt
    ```
-3. Create a new branch for your work:
+3. Start the FastAPI server in development mode (runs at `http://localhost:8000`):
+   ```sh
+   uvicorn backend.main:app --reload
+   ```
+   Once running, the interactive API docs are available at `http://localhost:8000/docs`.
+4. Set up the React frontend:
+   ```sh
+   cd frontend/videologs
+   npm install
+   ```
+5. Launch the React development server and open <http://localhost:3000>:
+   ```sh
+   npm start
+   ```
+6. Create a new branch for your work:
    ```sh
    git checkout -b my-feature
    ```
-4. Make changes and commit:
+7. Make changes and commit:
    ```sh
    git add .
    git commit -m "Describe your changes"
@@ -37,3 +51,18 @@ The project uses React and TailwindCSS for the frontend, and FastAPI with Whispe
    ```
 
 More documentation will be added as the project evolves.
+
+## Basic API Usage
+Once the server is running, you can create logs with a POST request and list them with a GET request.
+
+Create a log entry:
+```sh
+curl -X POST -H "Content-Type: application/json" \
+    -d '{"content": "First entry", "tags": ["test"]}' \
+    http://localhost:8000/logs
+```
+List log entries:
+```sh
+curl http://localhost:8000/logs
+```
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,7 +1,33 @@
 from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import List
+from datetime import datetime
 
 app = FastAPI()
+
+class LogCreate(BaseModel):
+    content: str
+    tags: List[str] = []
+
+class LogEntry(LogCreate):
+    id: int
+    timestamp: datetime
+
+log_entries: List[LogEntry] = []
+next_id = 1
 
 @app.get("/")
 async def read_root():
     return {"message": "Welcome to your FastAPI site!"}
+
+@app.post("/logs", response_model=LogEntry)
+async def create_log(entry: LogCreate):
+    global next_id
+    log = LogEntry(id=next_id, content=entry.content, tags=entry.tags, timestamp=datetime.utcnow())
+    next_id += 1
+    log_entries.append(log)
+    return log
+
+@app.get("/logs", response_model=List[LogEntry])
+async def list_logs():
+    return log_entries

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,27 @@
+import sys, os; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from fastapi.testclient import TestClient
+from backend.main import app, log_entries
+
+client = TestClient(app)
+
+def test_root():
+    resp = client.get('/')
+    assert resp.status_code == 200
+    assert resp.json() == {"message": "Welcome to your FastAPI site!"}
+
+def test_create_and_list_logs():
+    log_entries.clear()
+    payload = {"content": "hello", "tags": ["greeting"]}
+    r = client.post('/logs', json=payload)
+    assert r.status_code == 200
+    data = r.json()
+    assert data['content'] == payload['content']
+    assert data['tags'] == payload['tags']
+    assert 'id' in data and 'timestamp' in data
+
+    r2 = client.get('/logs')
+    assert r2.status_code == 200
+    logs = r2.json()
+    assert len(logs) == 1
+    assert logs[0]['content'] == payload['content']


### PR DESCRIPTION
## Summary
- document how to run the development servers
- add a basic API for creating and listing logs
- show example `curl` usage in README
- test the new FastAPI endpoints

## Testing
- `pip install -r backend/requirements.txt`
- `pip install httpx`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68645418ee608320ab9d72c4ec66e3f7