### PR TITLE
Create package initialization and cleanup test imports

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-import sys, os; sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from fastapi.testclient import TestClient
 from httpx import AsyncClient, ASGITransport
 import httpx


### PR DESCRIPTION
## Summary
- make `backend` a package to allow clean imports
- remove path manipulation in tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864711c95248320b5500f9f62e17157